### PR TITLE
[61] 내 주변 화장실 리스트 구성 및 리덕스 정리

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <title>POODADAK</title>
     <script
       crossorigin
-      src="https://apis.openapi.sk.com/tmap/jsv2?version=1&appKey=l7xxa9987e08abce420da89e0fd17ee212c6"
+      src="https://apis.openapi.sk.com/tmap/jsv2?version=1&appKey=l7xx66e7421614a24fb5b811213de86ca032"
     ></script>
   </head>
   <body>

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,12 +1,14 @@
 import { configureStore } from "@reduxjs/toolkit";
 
 import loginReducer from "../features/login/loginSlice";
-import currnetToiletInfoReducer from "../features/toilet/toiletSlice";
+import mainReducer from "../features/main/mainSlice";
+import toiletReducer from "../features/toilet/toiletSlice";
 
 const store = configureStore({
   reducer: {
     login: loginReducer,
-    currnetToiletInfo: currnetToiletInfoReducer,
+    main: mainReducer,
+    toilet: toiletReducer,
   },
 });
 

--- a/src/features/main/Main.js
+++ b/src/features/main/Main.js
@@ -14,8 +14,8 @@ import HeaderMain from "../../common/components/headers/HeaderMain";
 import Sidebar from "../../common/components/Sidebar";
 import ErrorPage from "../error/ErrorPage";
 import ToiletCard from "../toilet/ToiletCard";
-import { updateNearToilets } from "../toilet/toiletSlice";
-import { updateUserLocation, removeUserLocation } from "./mainSlice";
+import { nearToiletsUpdated } from "../toilet/toiletSlice";
+import { userLocationUpdated, userLocationRemoved } from "./mainSlice";
 import Start from "./Start";
 
 const StyledMain = styled.div`
@@ -81,7 +81,6 @@ function Main() {
   const [selectedToiletTime, setSelectedToiletTime] = useState(null);
   const [drawPathInfos, setDrawPathInfos] = useState([]);
   const [drawPathResults, setDrawPathResults] = useState([]);
-  // eslint-disable-next-line no-unused-vars
   const [pathMarkers, setPathMarkers] = useState([]);
   const [polyline, setPolyline] = useState(null);
   const [onSideBar, setOnSideBar] = useState(false);
@@ -148,7 +147,7 @@ function Main() {
         (position) => {
           const lng = position.coords.longitude;
           const lat = position.coords.latitude;
-          dispatch(updateUserLocation([lng, lat]));
+          dispatch(userLocationUpdated([lng, lat]));
           forceSetMapCenter([lng, lat]);
         },
         (error) => {
@@ -166,7 +165,7 @@ function Main() {
         }
       );
     } else {
-      dispatch(removeUserLocation());
+      dispatch(userLocationRemoved());
       const newErr = {
         title: "GPS를 지원하지 않습니다",
         description: "위치정보 제공에 동의해주셔야 앱을 사용하실 수 있습니다.",
@@ -245,7 +244,7 @@ function Main() {
             newNearToilets.push(newToilet);
           }
 
-          dispatch(updateNearToilets(newNearToilets));
+          dispatch(nearToiletsUpdated(newNearToilets));
         }
       }
     }
@@ -409,7 +408,7 @@ function Main() {
             (position) => {
               const lng = position.coords.longitude;
               const lat = position.coords.latitude;
-              dispatch(updateUserLocation([lng, lat]));
+              dispatch(userLocationUpdated([lng, lat]));
             },
             (error) => {
               const newErr = {
@@ -426,7 +425,7 @@ function Main() {
             }
           );
         } else {
-          dispatch(removeUserLocation());
+          dispatch(userLocationRemoved());
           const newErr = {
             title: "GPS를 지원하지 않습니다",
             description:

--- a/src/features/main/mainSlice.js
+++ b/src/features/main/mainSlice.js
@@ -9,17 +9,17 @@ export const mainSlice = createSlice({
   name: "main",
   initialState,
   reducers: {
-    updateUserLocation: (state, action) => {
+    userLocationUpdated: (state, action) => {
       state.gotUserLocation = true;
       state.userLocation = action.payload;
     },
-    removeUserLocation: (state) => {
+    userLocationRemoved: (state) => {
       state.gotUserLocation = false;
       state.userLocation = [];
     },
   },
 });
 
-export const { updateUserLocation, removeUserLocation } = mainSlice.actions;
+export const { userLocationUpdated, userLocationRemoved } = mainSlice.actions;
 
 export default mainSlice.reducer;

--- a/src/features/main/mainSlice.js
+++ b/src/features/main/mainSlice.js
@@ -1,0 +1,25 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  gotUserLocation: false,
+  userLocation: [],
+};
+
+export const mainSlice = createSlice({
+  name: "main",
+  initialState,
+  reducers: {
+    updateUserLocation: (state, action) => {
+      state.gotUserLocation = true;
+      state.userLocation = action.payload;
+    },
+    removeUserLocation: (state) => {
+      state.gotUserLocation = false;
+      state.userLocation = [];
+    },
+  },
+});
+
+export const { updateUserLocation, removeUserLocation } = mainSlice.actions;
+
+export default mainSlice.reducer;

--- a/src/features/toilet/Toilet.js
+++ b/src/features/toilet/Toilet.js
@@ -3,7 +3,7 @@
 /* eslint-disable camelcase */
 import axios from "axios";
 import React, { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 
@@ -19,7 +19,6 @@ import ListDefault from "../../common/components/lists/ListDefault";
 import ReviewCard from "../../common/components/reviewCard/ReviewCard";
 import StarContainer from "../../common/components/starContainer/StarContainer";
 import Title from "../../common/components/Title";
-import { toiletInfoUpated } from "./toiletSlice";
 
 const StyledToilet = styled.div`
   width: 100%;
@@ -56,7 +55,6 @@ const StyledToilet = styled.div`
 function Toilet() {
   const { toilet_id } = useParams();
   const navigate = useNavigate();
-  const dispatch = useDispatch();
   const location = useLocation();
 
   const {
@@ -72,7 +70,6 @@ function Toilet() {
     ladiesChildrenToiletBowlNumber,
     openTime,
     latestToiletPaperInfo,
-    isSOS,
     chatRoomList,
   } = location.state;
 
@@ -85,11 +82,7 @@ function Toilet() {
 
   const [reviews, setReviews] = useState([]);
   const [avgRating, setAvgRating] = useState(0);
-  const [userSOSButton, setUserSOSButton] = useState(userClickedSOSButton);
-
-  useEffect(() => {
-    dispatch(toiletInfoUpated({ toilet_id, isSOS, userSOSButton }));
-  }, [userSOSButton]);
+  // const [userSOSButton, setUserSOSButton] = useState(userClickedSOSButton); ==> 용처가 확실치 않아서 우선 주석처리
 
   useEffect(() => {
     async function getReviews() {
@@ -103,6 +96,7 @@ function Toilet() {
     }
 
     getReviews();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -121,7 +115,7 @@ function Toilet() {
   }, [reviews]);
 
   function onClickSOSButton() {
-    setUserSOSButton(true);
+    // setUserSOSButton(true); ==> 용처가 확실치 않아서 우선 주석처리
 
     async function emitSOS() {
       try {

--- a/src/features/toilet/Toilet.js
+++ b/src/features/toilet/Toilet.js
@@ -82,7 +82,6 @@ function Toilet() {
 
   const [reviews, setReviews] = useState([]);
   const [avgRating, setAvgRating] = useState(0);
-  // const [userSOSButton, setUserSOSButton] = useState(userClickedSOSButton); ==> 용처가 확실치 않아서 우선 주석처리
 
   useEffect(() => {
     async function getReviews() {

--- a/src/features/toilet/ToiletCard.js
+++ b/src/features/toilet/ToiletCard.js
@@ -76,8 +76,8 @@ function ToiletCard({ toilet, distance, time }) {
     ladiesToiletBowlNumber,
   } = toilet;
 
-  function moveToiletDetail() {
-    // e.stopPropagation(); ==> 실제 페이지로 넘어가는데 있어서 의미를 몰라 우선 주석처리
+  function moveToiletDetail(e) {
+    e.stopPropagation();
     navigate(`/toilets/${_id}`, {
       state: toilet,
     });
@@ -90,7 +90,7 @@ function ToiletCard({ toilet, distance, time }) {
           <div className="distance">
             {distance}m (도보 {time}분)
           </div>
-          <ButtonDefault moveTo="right" onClick={() => moveToiletDetail()}>
+          <ButtonDefault moveTo="right" onClick={(e) => moveToiletDetail(e)}>
             상세정보
           </ButtonDefault>
         </div>

--- a/src/features/toilet/ToiletCard.js
+++ b/src/features/toilet/ToiletCard.js
@@ -68,7 +68,7 @@ const StyledToiletCard = styled.div`
 function ToiletCard({ toilet, distance, time }) {
   const navigate = useNavigate();
   const {
-    _id,
+    _id: toiletId,
     isSOS,
     toiletName,
     roadNameAddress,
@@ -78,7 +78,7 @@ function ToiletCard({ toilet, distance, time }) {
 
   function moveToiletDetail(e) {
     e.stopPropagation();
-    navigate(`/toilets/${_id}`, {
+    navigate(`/toilets/${toiletId}`, {
       state: toilet,
     });
   }

--- a/src/features/toilet/ToiletCard.js
+++ b/src/features/toilet/ToiletCard.js
@@ -13,7 +13,7 @@ const StyledToiletCard = styled.div`
   justify-content: center;
 
   .wrapper {
-    width: 70%;
+    width: 80%;
     height: fit-content;
     display: flex;
     flex-direction: column;
@@ -32,7 +32,7 @@ const StyledToiletCard = styled.div`
     align-items: center;
     .distance {
       padding: 0.3rem 0.8rem;
-      margin-left: 10px;
+      margin-left: 11%;
       margin-bottom: -0.5rem;
       border-radius: 0.3rem;
       background-color: #c0c0c0;
@@ -68,7 +68,7 @@ const StyledToiletCard = styled.div`
 function ToiletCard({ toilet, distance, time }) {
   const navigate = useNavigate();
   const {
-    toiletID,
+    _id,
     isSOS,
     toiletName,
     roadNameAddress,
@@ -76,9 +76,9 @@ function ToiletCard({ toilet, distance, time }) {
     ladiesToiletBowlNumber,
   } = toilet;
 
-  function moveToiletDetail(e) {
-    e.stopPropagation();
-    navigate(`/toilets/${toiletID}`, {
+  function moveToiletDetail() {
+    // e.stopPropagation(); ==> 실제 페이지로 넘어가는데 있어서 의미를 몰라 우선 주석처리
+    navigate(`/toilets/${_id}`, {
       state: toilet,
     });
   }
@@ -90,7 +90,7 @@ function ToiletCard({ toilet, distance, time }) {
           <div className="distance">
             {distance}m (도보 {time}분)
           </div>
-          <ButtonDefault moveTo="right" onClick={(e) => moveToiletDetail(e)}>
+          <ButtonDefault moveTo="right" onClick={() => moveToiletDetail()}>
             상세정보
           </ButtonDefault>
         </div>
@@ -112,7 +112,7 @@ function ToiletCard({ toilet, distance, time }) {
 
 ToiletCard.propTypes = {
   toilet: PropTypes.shape({
-    toiletID: PropTypes.string,
+    _id: PropTypes.string,
     isSOS: PropTypes.bool,
     toiletName: PropTypes.string,
     roadNameAddress: PropTypes.string,

--- a/src/features/toilet/Toilets.js
+++ b/src/features/toilet/Toilets.js
@@ -1,22 +1,52 @@
 import React from "react";
-// import { useNavigate } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 
 import HeaderSub from "../../common/components/headers/HeaderSub";
+import Title from "../../common/components/Title";
+import ToiletCard from "./ToiletCard";
 
 const StyledToilets = styled.div`
   width: 100%;
+  min-height: 568px;
   display: flex;
   flex-direction: column;
+  align-items: center;
   background-color: black;
+  .title {
+    width: 90%;
+  }
+  .list {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+  }
 `;
 
 function Toilets() {
-  // const navigate = useNavigate();
+  const location = useLocation();
+
+  const toilets = location.state;
 
   return (
     <StyledToilets>
       <HeaderSub />
+      <div className="title">
+        <Title
+          title="내 주변 화장실"
+          description="내 주변 반경 500m 이내 화장실 리스트 입니다."
+        />
+      </div>
+      <div className="list">
+        {toilets &&
+          Array.from(toilets).map((toilet) => (
+            <ToiletCard
+              toilet={toilet}
+              distance={toilet.tDistance}
+              time={toilet.tTime}
+            />
+          ))}
+      </div>
     </StyledToilets>
   );
 }

--- a/src/features/toilet/toiletSlice.js
+++ b/src/features/toilet/toiletSlice.js
@@ -8,12 +8,12 @@ export const toiletSlice = createSlice({
   name: "toilet",
   initialState,
   reducers: {
-    updateNearToilets: (state, action) => {
+    nearToiletsUpdated: (state, action) => {
       state.nearToilets = action.payload;
     },
   },
 });
 
-export const { updateNearToilets } = toiletSlice.actions;
+export const { nearToiletsUpdated } = toiletSlice.actions;
 
 export default toiletSlice.reducer;

--- a/src/features/toilet/toiletSlice.js
+++ b/src/features/toilet/toiletSlice.js
@@ -1,51 +1,19 @@
-/* eslint-disable camelcase */
 import { createSlice } from "@reduxjs/toolkit";
 
+const initialState = {
+  nearToilets: [],
+};
+
 export const toiletSlice = createSlice({
-  name: "currnetToiletInfo",
-  initialState: {
-    allIds: [],
-    byIds: {},
-  },
+  name: "toilet",
+  initialState,
   reducers: {
-    toiletInfoUpated: (state, action) => {
-      const { toilet_id, isSOS, userSOSButton } = action.payload;
-
-      if (!state.allIds.lengths) {
-        const newState = {
-          allIds: [toilet_id],
-          byIds: {
-            [toilet_id]: {
-              isSOSCurrnetToilet: isSOS,
-              userClickedSOSButton: userSOSButton,
-            },
-          },
-        };
-        return newState;
-      }
-
-      if (!state.allIds.includes(toilet_id)) {
-        const newState = {
-          allIds: [toilet_id],
-          byIds: {
-            [toilet_id]: {
-              isSOSCurrnetToilet: isSOS,
-              userClickedSOSButton: userSOSButton,
-            },
-          },
-        };
-
-        return state.push(newState);
-      }
-
-      state.byIds[toilet_id].isSOSCurrnetToilet = isSOS;
-      state.byIds[toilet_id].userClickedSOSButton = userSOSButton;
-
-      return state;
+    updateNearToilets: (state, action) => {
+      state.nearToilets = action.payload;
     },
   },
 });
 
-export const { toiletInfoUpated } = toiletSlice.actions;
+export const { updateNearToilets } = toiletSlice.actions;
 
 export default toiletSlice.reducer;


### PR DESCRIPTION
## Description
- 노션 칸반 카드 링크: [[61] main - map + list](https://www.notion.so/vanillacoding/main-map-list-760a875387c644e09b5a648ed1c5d375)
- 메인 기본기능 구현이 완료되었습니다.
- 기획 추가사항도 구현 완료되었습니다.
    - 리스트는 내 주면 화장실만 노출
    - 내 위치로 강제로 이동하기
- 특이사항은 아래와 같습니다.
    - 메인 최적화 추가작업 필요할 것으로 보여서 별도 칸반 카드를 만들었습니다. (체크리스트 확인 요)
    - 외부 api를 활용하다보니 lint 적용 이슈에 반하는 케이스가 많이 있습니다. lint 예외처리 주석 확인 및 논의가 필요합니다.

## Checklist
- [x]  헤더
    - [x]  사이드바 링크 처리
- [x]  내 위치 파악 버튼 처리
- [x]  맵 배경 UI
- [x]  현재위치 pin 찍기
- [x]  리스트 보기 버튼 처리
- [x]  화장실 리스트 가져오고 pin 찍기
    - [x]  기본: 반경 500m 내 화장실 모두 가져오기
    - [x]  만약 쿼리값이 0일 경우 반경 500m 추가해서 다시 쿼리      
        → 안하기로 함. 현재 위치 기반으로만 쿼리하고 나머지는 열람만 가능하도록 구성
    - [x]  계속 이어서 쿼리에 1개 이상의 화장실이 노출되면 반경확장 멈춤
        → 안하기로 함. 현재 위치 기반으로만 쿼리하고 나머지는 열람만 가능하도록 구성
- [x]  화장실 선택 시 경로 노출
    - [x]  화장실을 선택하면 그때부터 현재위치 지속적으로 트래킹
    - [x]  최적화 방법 고민 필요
        → 메인 최적화 카드로 별도로 진행
        [main -advanced](https://www.notion.so/main-advanced-cf6b3c94df024279b480b7e0d37a5c90)
    - [x]  선택한 화장실 카드 보여주기
- [x]  리스트
    - [x]  헤더
    - [x]  화장실 카드들 배치
- [x]  추가사항
    - [x]  내 주변 화장실 리스트는 내 현재위치 기준으로만 구성하고 노출한다.