### PR TITLE
[71] 프로필 페이지 구현.

### DIFF
--- a/src/common/api/getUserReviewList.js
+++ b/src/common/api/getUserReviewList.js
@@ -2,7 +2,6 @@ import axios from "axios";
 
 async function getUserReviewList(userId) {
   const { data } = await axios.get(`/profile/${userId}`);
-  // console.log("=======", data);
   return data;
 }
 

--- a/src/common/api/getUserReviewList.js
+++ b/src/common/api/getUserReviewList.js
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+async function getUserReviewList(userId) {
+  const { data } = await axios.get(`/profile/${userId}`);
+  // console.log("=======", data);
+  return data;
+}
+
+export default getUserReviewList;

--- a/src/common/components/reviewCard/ReviewCard.js
+++ b/src/common/components/reviewCard/ReviewCard.js
@@ -70,6 +70,12 @@ const StyledDiv = styled.div`
   height: 477px;
   background-color: black;
   color: white;
+
+  .toiletName {
+    margin: 0.5rem;
+    font-size: 1.5rem;
+    font-weight: bold;
+  }
 `;
 
 const PhotoReviewContainer = styled.div`
@@ -126,6 +132,7 @@ function ReviewCard({
   rating,
   isMyReview,
   reviewId,
+  toilet,
 }) {
   const [showCover, setShowCover] = useState(true);
   const navigate = useNavigate();
@@ -166,6 +173,11 @@ function ReviewCard({
     // 차후 리뷰 삭제 로직 구현 필요
   }
 
+  function handleToiletNameClick() {
+    // eslint-disable-next-line no-underscore-dangle
+    navigate(`/toilets/${toilet._id}`, { state: toilet });
+  }
+
   return (
     <StyledDiv>
       <StyledHeader>
@@ -181,6 +193,15 @@ function ReviewCard({
         </div>
         <div className="date">{updatedAt}</div>
       </StyledHeader>
+      <div
+        className="toiletName"
+        onClick={handleToiletNameClick}
+        onKeyPress={handleToiletNameClick}
+        role="button"
+        tabIndex={0}
+      >
+        {toilet.toiletName}
+      </div>
       <StarContainer rating={rating} />
       <p>{description}</p>
       {isImage && (
@@ -240,6 +261,29 @@ ReviewCard.propTypes = {
   rating: PropTypes.number.isRequired,
   isMyReview: PropTypes.bool.isRequired,
   reviewId: PropTypes.string.isRequired,
+  toilet: PropTypes.shape({
+    _id: PropTypes.string,
+    toiletType: PropTypes.string,
+    toiletName: PropTypes.string,
+    roadNameAddress: PropTypes.string,
+    indexNameAddress: PropTypes.string,
+    isUnisexToilet: PropTypes.bool,
+    menToiletBowlNumber: PropTypes.number,
+    menUrinalNumber: PropTypes.number,
+    menHandicapToiletBowlNumber: PropTypes.number,
+    menHandicapUrinalNumber: PropTypes.number,
+    menChildrenToiletBowlNumber: PropTypes.number,
+    menChildrenUrinalNumber: PropTypes.number,
+    ladiesToiletBowlNumber: PropTypes.number,
+    ladiesHandicapToiletBowlNumber: PropTypes.number,
+    ladiesChildrenToiletBowlNumber: PropTypes.number,
+    openTime: PropTypes.string,
+    latestToiletPaperInfo: PropTypes.shape({
+      lastDate: PropTypes.string,
+      isToiletPaper: PropTypes.bool,
+    }),
+    isSOS: PropTypes.bool,
+  }).isRequired,
 };
 
 export default ReviewCard;

--- a/src/common/components/reviewCard/ReviewCard.js
+++ b/src/common/components/reviewCard/ReviewCard.js
@@ -69,6 +69,7 @@ const StyledDiv = styled.div`
   width: 100%;
   height: 477px;
   background-color: black;
+  color: white;
 `;
 
 const PhotoReviewContainer = styled.div`

--- a/src/common/components/userLevel/UserLevel.js
+++ b/src/common/components/userLevel/UserLevel.js
@@ -1,0 +1,80 @@
+import PropTypes from "prop-types";
+import React from "react";
+import styled from "styled-components";
+
+import bronze from "../../../assets/icon-rank-bronze.png";
+import gold from "../../../assets/icon-rank-gold.png";
+import silver from "../../../assets/icon-rank-silver.png";
+
+const UserLevelContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  color: white;
+
+  .rankIcon {
+    margin-left: 2rem;
+
+    img {
+      width: 70%;
+    }
+  }
+
+  .descriptionContainer {
+    width: 50%;
+    margin-right: 3rem;
+  }
+
+  .rank {
+    font-size: 1rem;
+    font-weight: bold;
+    margin-bottom: 1rem;
+  }
+
+  .description {
+    font-size: 0.75rem;
+    font-weight: 100;
+  }
+`;
+
+function UserLevel({ level }) {
+  let userRankImageSrc = bronze;
+  let description = "아직 부족한 휴지끈... 분발하세요";
+
+  if (level === "GOLD") {
+    userRankImageSrc = gold;
+    description = "🧻  프리미엄 휴지끈 보유자! 👍 ";
+  }
+
+  if (level === "SILVER") {
+    userRankImageSrc = silver;
+    description = "🧻  당신의 훌륭한 휴지끈 길이!";
+  }
+
+  if (level === "BRONZE") {
+    userRankImageSrc = bronze;
+    description = "🧻  아직 부족한 휴지끈... 분발하세요";
+  }
+
+  return (
+    <UserLevelContainer>
+      <div className="rankIcon">
+        <img src={userRankImageSrc} alt="rankIcon" />
+      </div>
+      <div className="descriptionContainer">
+        <div className="rank">등급 : {level}</div>
+        <div className="description">{description}</div>
+      </div>
+    </UserLevelContainer>
+  );
+}
+
+UserLevel.propTypes = {
+  level: PropTypes.string,
+};
+UserLevel.defaultProps = {
+  level: "BRONZE",
+};
+
+export default UserLevel;

--- a/src/features/profile/Profile.js
+++ b/src/features/profile/Profile.js
@@ -7,6 +7,7 @@ import getUserReviewList from "../../common/api/getUserReviewList";
 import HeaderSub from "../../common/components/headers/HeaderSub";
 import ReviewCard from "../../common/components/reviewCard/ReviewCard";
 import Title from "../../common/components/Title";
+import UserLevel from "../../common/components/userLevel/UserLevel";
 
 const StyledProfile = styled.div`
   width: 100%;
@@ -19,6 +20,7 @@ function Profile() {
   const { userId } = useParams();
   const [userInfo, setUserInfo] = useState({});
   const [reviewList, setReviewList] = useState([]);
+
   // eslint-disable-next-line no-unused-vars
   const navigate = useNavigate();
 
@@ -35,29 +37,26 @@ function Profile() {
     <StyledProfile>
       <HeaderSub />
       <Title title={userInfo.username} />
-      {/* 등급표시 어떻게 할건지 파악 */}
+      <UserLevel level={userInfo.level} />
       <Title
         title="리뷰"
         description={`총 ${reviewList.length}개의 리뷰가 있습니다.`}
       />
-      {reviewList.map((review) => {
-        // eslint-disable-next-line no-console
-        console.log("12341234", review);
-        return (
-          <ReviewCard
-            userId={userId}
-            username={userInfo.username}
-            level={userInfo.level}
-            updatedAt={review.updatedAt}
-            image={review.image}
-            description={review.description}
-            rating={review.rating}
-            isMyReview={false}
-            reviewId={review._id}
-            key={review._id}
-          />
-        );
-      })}
+      {reviewList.map((review) => (
+        <ReviewCard
+          userId={userId}
+          username={userInfo.username}
+          level={userInfo.level}
+          updatedAt={review.updatedAt}
+          image={review.image}
+          description={review.description}
+          rating={review.rating}
+          isMyReview={false}
+          toilet={review.toilet}
+          reviewId={review._id}
+          key={review._id}
+        />
+      ))}
     </StyledProfile>
   );
 }

--- a/src/features/profile/Profile.js
+++ b/src/features/profile/Profile.js
@@ -1,13 +1,9 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable prettier/prettier */
-
+/* eslint-disable no-underscore-dangle */
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
-// import { useNavigate } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
-// import getReview from "../../common/api/getReview";
-
+import getUserReviewList from "../../common/api/getUserReviewList";
 import HeaderSub from "../../common/components/headers/HeaderSub";
 import ReviewCard from "../../common/components/reviewCard/ReviewCard";
 import Title from "../../common/components/Title";
@@ -21,26 +17,47 @@ const StyledProfile = styled.div`
 
 function Profile() {
   const { userId } = useParams();
-  // eslint-disable-next-line no-unused-vars
+  const [userInfo, setUserInfo] = useState({});
   const [reviewList, setReviewList] = useState([]);
-  // const navigate = useNavigate();
-  // console.log(userId);
+  // eslint-disable-next-line no-unused-vars
+  const navigate = useNavigate();
 
-  // useEffect(async () => {
-  //   const response = await getReviewByUserID();
-  // }, []);
+  useEffect(() => {
+    (async function getReviewLit() {
+      const response = await getUserReviewList(userId);
+      setUserInfo(response);
+      setReviewList(response.reviewList);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <StyledProfile>
       <HeaderSub />
-      <Title title="유저네임" />
+      <Title title={userInfo.username} />
       {/* 등급표시 어떻게 할건지 파악 */}
       <Title
         title="리뷰"
-        description={`총 ${`reviews.length`}개의 리뷰가 있습니다.`}
+        description={`총 ${reviewList.length}개의 리뷰가 있습니다.`}
       />
-      <ReviewCard />
-      {/* 가져온 리뷰 뿌려주기 */}
+      {reviewList.map((review) => {
+        // eslint-disable-next-line no-console
+        console.log("12341234", review);
+        return (
+          <ReviewCard
+            userId={userId}
+            username={userInfo.username}
+            level={userInfo.level}
+            updatedAt={review.updatedAt}
+            image={review.image}
+            description={review.description}
+            rating={review.rating}
+            isMyReview={false}
+            reviewId={review._id}
+            key={review._id}
+          />
+        );
+      })}
     </StyledProfile>
   );
 }

--- a/src/features/profile/Profile.js
+++ b/src/features/profile/Profile.js
@@ -1,8 +1,16 @@
-import React from "react";
+/* eslint-disable no-unused-vars */
+/* eslint-disable prettier/prettier */
+
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 // import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
+// import getReview from "../../common/api/getReview";
+
 import HeaderSub from "../../common/components/headers/HeaderSub";
+import ReviewCard from "../../common/components/reviewCard/ReviewCard";
+import Title from "../../common/components/Title";
 
 const StyledProfile = styled.div`
   width: 100%;
@@ -12,11 +20,27 @@ const StyledProfile = styled.div`
 `;
 
 function Profile() {
+  const { userId } = useParams();
+  // eslint-disable-next-line no-unused-vars
+  const [reviewList, setReviewList] = useState([]);
   // const navigate = useNavigate();
+  // console.log(userId);
+
+  // useEffect(async () => {
+  //   const response = await getReviewByUserID();
+  // }, []);
 
   return (
     <StyledProfile>
       <HeaderSub />
+      <Title title="유저네임" />
+      {/* 등급표시 어떻게 할건지 파악 */}
+      <Title
+        title="리뷰"
+        description={`총 ${`reviews.length`}개의 리뷰가 있습니다.`}
+      />
+      <ReviewCard />
+      {/* 가져온 리뷰 뿌려주기 */}
     </StyledProfile>
   );
 }

--- a/src/features/toilet/Toilet.js
+++ b/src/features/toilet/Toilet.js
@@ -4,6 +4,7 @@
 import axios from "axios";
 import haversine from "haversine-distance";
 import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 
@@ -25,7 +26,6 @@ import ReviewCard from "../../common/components/reviewCard/ReviewCard";
 import StarContainer from "../../common/components/starContainer/StarContainer";
 import Title from "../../common/components/Title";
 import { userCreatedChat, userClosedChat } from "../chat/chatSlice";
-
 
 const StyledToilet = styled.div`
   width: 100%;
@@ -73,10 +73,12 @@ function Toilet() {
   const { toilet_id } = useParams();
   const navigate = useNavigate();
   const location = useLocation();
+  const dispatch = useDispatch();
   const toilet = location.state;
 
   const [toiletLongitude, toiletLatitude] = toilet.location.coordinates;
   const isLoggedIn = useSelector((state) => state.login.isLoggedIn);
+  // eslint-disable-next-line no-unused-vars
   const myChat = useSelector((state) => state.chat.myChat);
 
   const [reviews, setReviews] = useState([]);
@@ -309,6 +311,7 @@ function Toilet() {
           rating={review.rating}
           isMyReview={false}
           reviewId={review._id}
+          toilet={review.toilet}
           key={review._id}
         />
       ))}

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ ReactDOM.render(
           <Route path="/chats/:chat_id" element={<Chat />} />
           <Route path="/editReview" element={<ReviewEdit />} />
           <Route path="/editReview/:reviewId" element={<ReviewEdit />} />
-          <Route path="/users/:user_id" element={<Profile />} />
+          <Route path="/users/:userId" element={<Profile />} />
           <Route path="/editProfile/:user_id" element={<ProfileEdit />} />
           <Route path="/error" element={<ErrorPage />} />
           <Route path="/ui" element={<Ui />} />


### PR DESCRIPTION
## Description
- 노션 칸반 카드 링크: [[[71]  프로필 상세 페이지](https://www.notion.so/vanillacoding/profile-reviews-541dd3d93d9c4a859642ba28926d38f7)]
- 유저 등급을 표시하는 컴포넌트를 추가하였습니다.
- 리뷰 컴포넌트에 화장실 이름을 추가하였습니다.
- 화장실 이름 클릭시 화장실 상세정보 페이지로 이동합니다.
- 유저이름 클릭시 해당 유저의 프로필로 이동합니다.

- [User 식별 및 등급정보 구성](https://www.notion.so/vanillacoding/User-5660d6328e9244f09f02b25ee9dc5dfe) 작업 이후, 프로필 페이지에서 본인 리뷰의 경우 수정 및 삭제버튼 노출되도록 추가 해야합니다.

## Checklist
- [x]  헤더
- [x]  유저 등급 표시
- [x]  리뷰 리스트 노출
- [x]  리뷰 노출시, 화장실 이름 추가.
- [x]  화장실 이름 클릭시 화장실 정보 페이지로 이동.
- [x]  리뷰어 이름 클릭시 리뷰어 프로필로 이동.
