### PR TITLE
[64] 휴지확인 날자에 dayjs 적용.

### DIFF
--- a/src/features/toilet/Toilet.js
+++ b/src/features/toilet/Toilet.js
@@ -2,6 +2,7 @@
 /* eslint-disable no-console */
 /* eslint-disable camelcase */
 import axios from "axios";
+import dayjs from "dayjs";
 import haversine from "haversine-distance";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -376,7 +377,8 @@ function Toilet() {
             secondary={toilet.latestToiletPaperInfo.isToiletPaper ? "O" : "X"}
           />
           <div className="lastToiletPaterProvideTime">
-            마지막 확인 : {toilet.latestToiletPaperInfo.lastDate}
+            마지막 확인 :{" "}
+            {dayjs(toilet.latestToiletPaperInfo.lastDate).format("YYYY/MM/DD")}
           </div>
         </div>
         <ListDefault


### PR DESCRIPTION
## Description
- 노션 칸반 카드 링크: [[64] toilet - info](https://www.notion.so/vanillacoding/toilet-info-b674d4524e6c4f9780cf0568568e9ac9)

기존의 toilet 컴포넌트의 날자출력에 dayjs를 적용해서 포맷된 날자를 출력하도록 했습니다. 

## Checklist
- [x] 목업과 동일한 포멧으로 날자를 포맷팅 했습니다. 