### PR TITLE
[86] 메인 로더 추가 및 전반적인 CSS 레이아웃 정비

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "prop-types": "^15.8.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-loader-spinner": "^5.1.3",
         "react-redux": "^7.2.6",
         "react-router-dom": "^6.2.1",
         "react-scripts": "5.0.0",
@@ -16481,6 +16482,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-loader-spinner": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/react-loader-spinner/-/react-loader-spinner-5.1.3.tgz",
+      "integrity": "sha512-wYDB9wNER7Q3oXBMso/k1ryhTsQdjzvCTWJmiGrVH8bsufwkpVix1C4jiULzthR6YECzaPxFEKR/RQ8JSArhOA==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/react-redux": {
       "version": "7.2.6",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
@@ -31238,6 +31248,12 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-loader-spinner": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/react-loader-spinner/-/react-loader-spinner-5.1.3.tgz",
+      "integrity": "sha512-wYDB9wNER7Q3oXBMso/k1ryhTsQdjzvCTWJmiGrVH8bsufwkpVix1C4jiULzthR6YECzaPxFEKR/RQ8JSArhOA==",
+      "requires": {}
     },
     "react-redux": {
       "version": "7.2.6",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-loader-spinner": "^5.1.3",
     "react-redux": "^7.2.6",
     "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0",

--- a/src/common/components/GlobalStyle.js
+++ b/src/common/components/GlobalStyle.js
@@ -2,22 +2,25 @@ import { createGlobalStyle } from "styled-components";
 
 const GlobalStyle = createGlobalStyle`
   html {
-    width: auto;
-    height: 90%;
+    width: 100vw;
+    height: 93.4%;
+    background-color: white;
+    margin: 0;
+    padding: 0;
     display: flex;
     flex-direction: column;
     align-items: center;
-    background-color: white;
   }
 
   body {
     flex-grow: 1;
+    width: 100%;
+    min-width: 320px;
+    max-width: 428px;
+    font-family: Noto Sans KR, sans-serif;
+    margin: 0;
     display: flex;
     flex-direction: column;
-    width: 100%;
-    max-width: 428px;
-    min-width: 320px;
-    font-family: Noto Sans KR, sans-serif;
   }
 
   #root {

--- a/src/common/components/lists/ListDefault.js
+++ b/src/common/components/lists/ListDefault.js
@@ -13,7 +13,7 @@ const StyledListDefault = styled.div`
 
   .label {
     font-size: large;
-    font-weight: 600;
+    font-weight: 400;
     color: #bc955c;
     margin-left: 20px;
     display: flex;
@@ -21,7 +21,7 @@ const StyledListDefault = styled.div`
   }
 
   .btns {
-    margin-right: 20px;
+    margin-right: 10px;
   }
   .secondary {
     font-size: medium;

--- a/src/common/components/starContainer/StarContainer.js
+++ b/src/common/components/starContainer/StarContainer.js
@@ -7,26 +7,22 @@ import starFull from "../../../assets/icon-star-full.png";
 import starHalf from "../../../assets/icon-star-half.png";
 
 const StyledDiv = styled.div`
-  margin: 3% 0;
   display: flex;
   align-items: center;
   width: ${(props) => props.width};
 
   .star {
-    width: 100%;
-    height: 100%;
+    width: 2rem;
   }
 
   .rating-number {
-    font-size: 0.8rem;
-    margin: 0 0.7rem;
+    font-size: 1rem;
   }
 `;
 
 const ImageContainer = styled.div`
   display: flex;
   align-items: center;
-  width: 17%;
 `;
 
 function StarContainer({ rating, showRatingNumber, onClick, width }) {

--- a/src/features/error/ErrorPage.js
+++ b/src/features/error/ErrorPage.js
@@ -7,7 +7,8 @@ import ButtonSmall from "../../common/components/buttons/ButtonSmall";
 
 const StyledErrorPage = styled.div`
   width: 100%;
-  height: 100%;
+  height: 100vh;
+  flex-grow: 1;
   background-color: black;
   color: white;
   display: flex;

--- a/src/features/main/Main.js
+++ b/src/features/main/Main.js
@@ -1,6 +1,7 @@
 /* eslint-disable new-cap */
 import axios from "axios";
 import React, { useEffect, useState, useCallback } from "react";
+import { Rings } from "react-loader-spinner";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
@@ -23,11 +24,22 @@ const StyledMain = styled.div`
   height: 100%;
   min-height: 568px;
   max-height: 100%;
+  .loader {
+    position: absolute;
+    top: 30%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    z-index: 5;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
   .map-container {
     position: absolute;
-    z-index: 0;
     top: 40;
     left: 0;
+    z-index: 0;
     width: 100%;
     height: 100%;
     display: flex;
@@ -39,9 +51,9 @@ const StyledMain = styled.div`
   }
   .card {
     position: absolute;
-    z-index: 1;
     bottom: 0;
     width: 100%;
+    z-index: 1;
     margin-bottom: 4px;
     .close {
       display: flex;
@@ -84,6 +96,7 @@ function Main() {
   const [pathMarkers, setPathMarkers] = useState([]);
   const [polyline, setPolyline] = useState(null);
   const [onSideBar, setOnSideBar] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   const gotUserLocation = useSelector((state) => state.main.gotUserLocation);
   const currentLocation = useSelector((state) => state.main.userLocation);
@@ -142,12 +155,14 @@ function Main() {
 
   function getLocation() {
     if (navigator.geolocation) {
+      setIsLoading(true);
       navigator.geolocation.getCurrentPosition(
         (position) => {
           const lng = position.coords.longitude;
           const lat = position.coords.latitude;
           dispatch(userLocationUpdated([lng, lat]));
           forceSetMapCenter([lng, lat]);
+          setIsLoading(false);
         },
         (error) => {
           const newErr = {
@@ -450,6 +465,17 @@ function Main() {
           </ButtonFull>
         </div>
       </div>
+
+      {isLoading && (
+        <div className="loader">
+          <Rings
+            height="100%"
+            width="200%"
+            color="#bc955c"
+            ariaLabel="loading"
+          />
+        </div>
+      )}
 
       {selectedToilet && (
         <div className="card">

--- a/src/features/profile/Profile.js
+++ b/src/features/profile/Profile.js
@@ -12,6 +12,7 @@ import UserLevel from "../../common/components/userLevel/UserLevel";
 
 const StyledProfile = styled.div`
   width: 100%;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   background-color: black;

--- a/src/features/review/ReviewEdit.js
+++ b/src/features/review/ReviewEdit.js
@@ -20,7 +20,7 @@ import { COLOR } from "../../common/util/constants";
 const StyledDiv = styled.div`
   position: relative;
   width: 100%;
-  height: 100%;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   background-color: black;
@@ -94,11 +94,15 @@ const StyledMain = styled.main`
   textarea {
     box-sizing: border-box;
     width: 100%;
-    height: 30%;
+    min-height: 10rem;
     resize: none;
     font-family: inherit;
     font-size: inherit;
     margin-bottom: 1rem;
+    padding: 0.5rem;
+    ::placeholder {
+      font-size: medium;
+    }
   }
 `;
 

--- a/src/features/toilet/Toilet.js
+++ b/src/features/toilet/Toilet.js
@@ -35,21 +35,33 @@ import {
 
 const StyledToilet = styled.div`
   width: 100%;
-  flex-grow: 1;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   background-color: black;
   color: white;
 
   .titleContainer {
+    padding: 0rem 1rem;
     display: flex;
-    align-items: center;
+    .buttonContainer {
+      margin-top: 0.5rem;
+      display: flex;
+    }
   }
 
   .rankContainer {
+    font-size: large;
+    font-weight: 400;
+    padding: 1rem;
     display: flex;
+    justify-content: center;
     align-items: center;
-    justify-content: space-evenly;
+    gap: 1rem;
+  }
+
+  .toiletInfoContainer {
+    padding: 1rem;
   }
 
   .toiletPaperContainer {
@@ -63,6 +75,10 @@ const StyledToilet = styled.div`
     font-size: small;
     color: gray;
     margin-right: 1rem;
+  }
+
+  .reviewContainer {
+    padding: 1rem;
   }
 
   .fluidButtonWrapper {
@@ -342,8 +358,10 @@ function Toilet() {
       <HeaderSub onClick={handleWaitingSaviorClick} />
       <div className="titleContainer">
         <Title title={toilet.toiletName} description={toilet.roadNameAddress} />
-        <ButtonDefault onClick={onClickSOSButton} icon={squaredSOS} />
-        <ButtonDefault onClick={blablablabla} icon={viewFinder} />
+        <div className="buttonContainer">
+          <ButtonDefault onClick={onClickSOSButton} icon={squaredSOS} />
+          <ButtonDefault onClick={blablablabla} icon={viewFinder} />
+        </div>
       </div>
       <div className="fluidButtonWrapper">
         {!currentSocket && showRescueButton && (
@@ -369,7 +387,13 @@ function Toilet() {
       </div>
       <div className="rankContainer">
         <div>청결도 평균 ( {avgRating} ) </div>
-        <StarContainer rating={avgRating} showRatingNumber={false} />
+        <div>
+          <StarContainer
+            className="star"
+            rating={avgRating}
+            showRatingNumber={false}
+          />
+        </div>
       </div>
       <div className="toiletInfoContainer">
         <ListDefault label="개방시간" secondary={toilet.openTime} />
@@ -400,34 +424,36 @@ function Toilet() {
           secondary={`남아 : ${toilet.menChildrenToiletBowlNumber}  /  여아 : ${toilet.ladiesChildrenToiletBowlNumber}`}
         />
       </div>
-      <Title
-        title="리뷰"
-        description={`총 ${reviews.length}개의 리뷰가 있습니다.`}
-      />
-      <div className="fluidButtonWrapper">
-        <ButtonFluid
-          icon={docuIcon}
-          color="#bc955c"
-          onClick={onClickCreatReview}
-        >
-          리뷰 남기기
-        </ButtonFluid>
-      </div>
-      {reviews.map((review) => (
-        <ReviewCard
-          userId={review.writer._id}
-          username={review.writer.username}
-          level={review.writer.level}
-          updatedAt={review.updatedAt}
-          image={review.image}
-          description={review.description}
-          rating={review.rating}
-          isMyReview={false}
-          reviewId={review._id}
-          toilet={review.toilet}
-          key={review._id}
+      <div className="reviewContainer">
+        <Title
+          title="리뷰"
+          description={`총 ${reviews.length}개의 리뷰가 있습니다.`}
         />
-      ))}
+        <div className="fluidButtonWrapper">
+          <ButtonFluid
+            icon={docuIcon}
+            color="#bc955c"
+            onClick={onClickCreatReview}
+          >
+            리뷰 남기기
+          </ButtonFluid>
+        </div>
+        {reviews.map((review) => (
+          <ReviewCard
+            userId={review.writer._id}
+            username={review.writer.username}
+            level={review.writer.level}
+            updatedAt={review.updatedAt}
+            image={review.image}
+            description={review.description}
+            rating={review.rating}
+            isMyReview={false}
+            reviewId={review._id}
+            toilet={review.toilet}
+            key={review._id}
+          />
+        ))}
+      </div>
     </StyledToilet>
   );
 }

--- a/src/features/toilet/Toilets.js
+++ b/src/features/toilet/Toilets.js
@@ -8,8 +8,7 @@ import ToiletCard from "./ToiletCard";
 
 const StyledToilets = styled.div`
   width: 100%;
-  height: 100%;
-  min-height: 568px;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import "react-loader-spinner/dist/loader/css/react-spinner-loader.css";
 
 import store from "./app/store";
 import GlobalStyle from "./common/components/GlobalStyle";


### PR DESCRIPTION
## Description
- 노션 칸반 카드 링크: [[86] CSS](https://www.notion.so/vanillacoding/CSS-fe34ff86faa847c789c713d8d84c31ca)
- 로더를 추가했습니다. pull 후 npm install을 해주세요.

## Checklist
- [x] 메인에 로더 추가
- [x] 전반적인 CSS 정비 (1차)
